### PR TITLE
Fix problem that may have made 'Hello World' print more than once

### DIFF
--- a/hajji/hello.S
+++ b/hajji/hello.S
@@ -40,7 +40,6 @@ start:
         xorw %ax, %ax
         movw %ax, %es
         movw %ax, %ds
-        movw %ax, %ss
 
         /*
          * Initialize the stack.
@@ -49,8 +48,15 @@ start:
          * we anchor it at $LOAD.  Note that we don't collide with
          * the code because the stack will always remain below
          * (i.e. less than) $LOAD and grows downwards from there.
+         * disable intterupts when setting up the stack. If an
+         * interrupt occurs between the two MOVs then the stack
+         * may point at the wrong memory location and the interrupt
+         * may crash the system
          */
+        cli
+        movw %ax, %ss
         movw $LOAD, %sp
+        sti
 
         /*
          * This is the "main" program:
@@ -61,6 +67,7 @@ start:
         callw clrscr                  # clear screen
         callw curshome                # move cursor home - top:left
         callw greeting                # display a greeting string
+		cli
 
         /*
          * That's all, folks!
@@ -69,8 +76,12 @@ start:
          * the processor.  When run on bare metal, a halted processor
          * consumes less power (especially useful if ran on battery).
          * When run under an emulator, the emulator doesn't consume
-         * further CPU cycles.
+         * further CPU cycles. Turn off interrupts before caling HLT
+         * because execution will only HLT until the next intterupt
+         * occurs. Once an interrupt occurs execution continues at
+         * the next instruction after HLT
          */
+        cli
         hlt
 
 /* greeting() -- display a little message. */

--- a/multiboot/osdev/linker.ld
+++ b/multiboot/osdev/linker.ld
@@ -19,6 +19,18 @@ SECTIONS
 		*(.text)
 	}
 
+	/* Make sure the GNU notes information is placed after .text. Failure to
+	   to do so may push the GRUB multiboot information beyond the first 8k
+       and GRUB will not identify this kernel as multiboot capable.
+       Alternative to this is to compile the final binary with this linker 
+       option to exclude this unqiue header:
+	   -Wl,--build-id=none */
+
+	.note.gnu.build-id BLOCK(4K) : ALIGN(4K)
+	{
+		*(.note.gnu.build-id)
+	}
+
 	/* Read-only data. */
 	.rodata BLOCK(4K) : ALIGN(4K)
 	{


### PR DESCRIPTION
Fix problem that may have made 'Hello World' print more than once or ended in unusual behavior. Ensure CLI is used before calling HLT so that interrupts don't restart the code after the HLT. Also ensure that when updating SS and SP that interrupts are off during the operation. It is possible for an interrupt to occur between the instructions causing the stack state to be invalid during interrupt execution,