### PR TITLE
Fix issue with GRUB not finding multiboot header

### DIFF
--- a/multiboot/osdev/linker.ld
+++ b/multiboot/osdev/linker.ld
@@ -19,6 +19,18 @@ SECTIONS
 		*(.text)
 	}
 
+	/* Make sure the GNU notes information is placed after .text. Failure to
+	   to do so may push the GRUB multiboot information beyond the first 8k
+	   and GRUB will not identify this kernel as multiboot capable.
+	   Alternative to this is to compile the final binary with this linker 
+	   option to exclude this unqiue header:
+	   -Wl,--build-id=none */
+
+	.note.gnu.build-id BLOCK(4K) : ALIGN(4K)
+	{
+		*(.note.gnu.build-id)
+	}
+
 	/* Read-only data. */
 	.rodata BLOCK(4K) : ALIGN(4K)
 	{


### PR DESCRIPTION
Modify the linker script to move the unique GNU information in
section .note.gnu.build-id after the .multiboot section. This
prevents the mulitboot header being pushed beyond the 8k position
in the kernel image.