### PR TITLE
Added an example of hello world without BIOS calls

### DIFF
--- a/baremetal_hello_world.S
+++ b/baremetal_hello_world.S
@@ -1,0 +1,38 @@
+#include "common.h"
+BEGIN
+    mov $0xB800, %di
+    mov %di, %es
+    xor %di, %di
+    lea msg, %si
+
+    // clear screen from SeaBIOS messages
+    xor  %ax, %ax
+    movw $2000, %cx
+    repz stosw
+
+    xor  %di, %di
+
+    // write a string on the screen
+.loop:
+    lodsb
+    test %al, %al
+    jz   .halt
+
+    // write the character
+    movb  %al, %es:(%di)
+
+    // write color attribute of this character
+    // 20d = 0x14 = 10100b = color attributes (red on blue)
+    // background color = 1b    = blue
+    // foreground color = 100b  = red
+    movb  $20, %es:1(%di)
+
+    add   $0x2, %di
+    jmp   .loop
+
+.halt:
+    hlt
+
+msg:
+    .asciz "    --> hello world! <--    "
+


### PR DESCRIPTION
Example uses the fact that BIOS maps video memory to address `0xB8000`. We can then move `0xB800` to a segment register and use `segment:offset` addressing to access this memory. Then we can show characters by treating `0xB800:0000` as a `uint16_t` array, where low 8 bytes is the ASCII character, and the high 8 bytes is the color attribute of this character.